### PR TITLE
fix: add missing @types/node and husky, update to bunx

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,10 +118,12 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^2.1.4",
     "@playwright/test": "^1.56.0",
     "bun-types": "^1.2.23",
     "drizzle-kit": "^0.31.5",
+    "husky": "^9.1.7",
     "typescript": "~5.9.3",
     "vitest": "^2.1.9"
   }

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -51,7 +51,7 @@ async function postInstall() {
 ✅ Third Eye MCP installed successfully!
 
 🚀 Quick Start:
-   npx third-eye-mcp up
+   bunx third-eye-mcp up
 
 📖 Documentation:
    • README.md                 — Project overview
@@ -60,12 +60,12 @@ async function postInstall() {
    • docs/                     — Full technical reference
 
 💡 Next steps:
-   1. Run: npx third-eye-mcp up
+   1. Run: bunx third-eye-mcp up
    2. Open http://127.0.0.1:3300
    3. Configure your API keys
    4. Connect your AI agent via docs/integrations
 
-For help: npx third-eye-mcp --help
+For help: bunx third-eye-mcp --help
 `);
 }
 


### PR DESCRIPTION
- Add @types/node for TypeScript compilation of workspace packages
- Add husky to fix prepare script error
- Update all instructions from npx to bunx (Bun-only runtime)
- Ensures build:packages succeeds during postinstall