### PR TITLE
fix: add @types/json-logic-js and fix expression evaluator types

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@types/json-logic-js": "^2.0.8",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^2.1.4",
     "@playwright/test": "^1.56.0",

--- a/packages/core/expression-evaluator.ts
+++ b/packages/core/expression-evaluator.ts
@@ -11,7 +11,7 @@
  * - Type-safe execution context
  */
 
-import jsonLogic from 'json-logic-js';
+import jsonLogic, { type RulesLogic } from 'json-logic-js';
 
 /**
  * Execution context available to expressions
@@ -104,7 +104,7 @@ export function evaluateExpression(
     }
 
     // Parse string expressions as JSON
-    let parsedExpression = expression;
+    let parsedExpression: object = typeof expression === 'string' ? {} : expression;
     if (typeof expression === 'string') {
       try {
         parsedExpression = JSON.parse(expression);
@@ -115,10 +115,12 @@ export function evaluateExpression(
           error: `Invalid JSON expression: ${parseError instanceof Error ? parseError.message : 'Unknown error'}`
         };
       }
+    } else {
+      parsedExpression = expression;
     }
 
     // Apply JSONLogic
-    const result = jsonLogic.apply(parsedExpression, context);
+    const result = jsonLogic.apply(parsedExpression as RulesLogic, context);
 
     return {
       success: true,


### PR DESCRIPTION
- Added @types/json-logic-js to devDependencies for proper TypeScript support
- Fixed type narrowing in expression-evaluator.ts for parsedExpression
- Import RulesLogic type from json-logic-js for strict typing

All packages and CLI now build successfully.