### PR TITLE
fix(postinstall): correct CLI invocation command for local development

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build:theme": "tsc --build packages/theme",
     "build:server": "bun run apps/server/src/build.ts",
     "build:ui": "bun run --cwd apps/ui build",
-    "build:cli": "bun build cli/index.ts --target=bun --outfile=dist/cli.js && bun build bin/mcp-server.ts --target=bun --outfile=dist/mcp-server.js",
+    "build:cli": "bun build cli/index.ts --target=bun --outfile=dist/cli.js --external='@third-eye/*' && bun build bin/mcp-server.ts --target=bun --outfile=dist/mcp-server.js --external='@third-eye/*'",
     "clean": "bun run clean:packages && bun run clean:apps && rm -rf dist",
     "clean:packages": "rm -rf packages/*/dist packages/*/*.tsbuildinfo",
     "clean:apps": "rm -rf apps/server/dist apps/ui/.next apps/ui/out",


### PR DESCRIPTION
Root cause: CLI build was failing during postinstall because bun bundler tried to bundle workspace packages but couldn't resolve them (packages have main pointing to source .ts files, not built .js files).

Changes:
1. Added --external='@third-eye/*' to CLI build command
2. This tells bun to NOT bundle workspace packages into CLI
3. Workspace packages are resolved at runtime as external dependencies

Fixes: "Could not resolve @third-eye/types" error during bun install

Verified:
- bun run build:cli succeeds
- dist/cli.js --help works correctly
- CLI can now use workspace packages at runtime