### PR TITLE
fix(config): Resolve TypeScript type error in getEyesByCapability

### DIFF
--- a/packages/config/eye-capabilities.ts
+++ b/packages/config/eye-capabilities.ts
@@ -106,7 +106,7 @@ export function getAllCapabilityTags(): readonly string[] {
 export function getEyesByCapability(capabilityTag: string): readonly EyeCapabilityName[] {
   const eyeNames: EyeCapabilityName[] = [];
   for (const [eyeName, capabilities] of Object.entries(EYE_CAPABILITIES)) {
-    if (capabilities.tags.includes(capabilityTag)) {
+    if ((capabilities.tags as readonly string[]).includes(capabilityTag)) {
       eyeNames.push(eyeName as EyeCapabilityName);
     }
   }


### PR DESCRIPTION
Fixed TS2345 error where capabilities.tags.includes() was failing
- Added explicit type cast to readonly string[] for tags array
- Issue: Object.entries() was losing type information from const object
- Solution: Cast capabilities.tags to maintain type compatibility

This fixes the build failure preventing 'bun third-eye-mcp up' from running.