### PR TITLE
fix(build): Consolidate migrations & fix TypeScript errors

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@inquirer/prompts": "^7.8.6",
         "@modelcontextprotocol/sdk": "^1.19.1",
+        "drizzle-orm": "^0.36.0",
         "json-logic-js": "^2.0.5",
         "kleur": "^4.1.5",
         "nanoid": "^5.1.6",
@@ -15,9 +16,12 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.56.0",
+        "@types/json-logic-js": "^2.0.8",
+        "@types/node": "^22.0.0",
         "@vitest/coverage-v8": "^2.1.4",
         "bun-types": "^1.2.23",
         "drizzle-kit": "^0.31.5",
+        "husky": "^9.1.7",
         "typescript": "~5.9.3",
         "vitest": "^2.1.9",
       },
@@ -27,8 +31,10 @@
       "version": "1.0.0",
       "dependencies": {
         "@third-eye/config": "workspace:*",
+        "@third-eye/constants": "workspace:*",
         "@third-eye/core": "workspace:*",
         "@third-eye/db": "workspace:*",
+        "@third-eye/eyes": "workspace:*",
         "@third-eye/providers": "workspace:*",
         "@third-eye/types": "workspace:*",
         "hono": "^4.6.0",
@@ -45,6 +51,8 @@
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource/geist-mono": "^5.2.7",
+        "@third-eye/config": "workspace:*",
+        "@third-eye/constants": "workspace:*",
         "@third-eye/core": "workspace:*",
         "@third-eye/theme": "workspace:*",
         "@third-eye/types": "workspace:*",
@@ -699,6 +707,8 @@
     "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/json-logic-js": ["@types/json-logic-js@2.0.8", "", {}, "sha512-WgNsDPuTPKYXl0Jh0IfoCoJoAGGYZt5qzpmjuLSEg7r0cKp/kWtWp0HAsVepyPSPyXiHo6uXp/B/kW/2J1fa2Q=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 

--- a/packages/core/auto-router.ts
+++ b/packages/core/auto-router.ts
@@ -12,6 +12,7 @@ import { EyeId, EyeStatusCode } from '@third-eye/constants';
 import { EyeOrchestrator } from './orchestrator';
 import { orderGuard } from './order-guard';
 import { ConversationTracker } from './conversation-tracker';
+import type { Constraint } from './routing/routing-modes';
 import { z } from 'zod';
 
 export interface AutoRouterOptions {
@@ -179,8 +180,8 @@ export class AutoRouter {
     if (routingMode === 'fixed' && options.templateId) {
       const { TemplateExecutor } = await import('./routing/template-executor');
       const { getDb } = await import('@third-eye/db');
-      const { db } = getDb();
-      const templateExecutor = new TemplateExecutor(db);
+      const { sqlite } = getDb();
+      const templateExecutor = new TemplateExecutor(sqlite);
 
       const executionPlan = await templateExecutor.executeTemplate(options.templateId);
 
@@ -217,8 +218,8 @@ export class AutoRouter {
     let overseerInput = enrichedInput;
     if (routingMode === 'constrained' && options.policyId) {
       const { getDb } = await import('@third-eye/db');
-      const { db } = getDb();
-      const policyRow = db
+      const { sqlite } = getDb();
+      const policyRow = sqlite
         .prepare(
           `SELECT id, name, description, mandatory_eyes, forbidden_eyes, min_validation_eyes, security_required, always_confirm_intent
            FROM routing_policies
@@ -272,10 +273,10 @@ export class AutoRouter {
     if (routingMode === 'constrained' && options.policyId) {
       const { PolicyValidator } = await import('./routing/policy-validator');
       const { getDb } = await import('@third-eye/db');
-      const { db } = getDb();
+      const { sqlite } = getDb();
 
       // Load policy from database
-      const policyRow = db
+      const policyRow = sqlite
         .prepare(
           `SELECT id, name, description, mandatory_eyes, forbidden_eyes, min_validation_eyes, security_required, always_confirm_intent, custom_constraints
            FROM routing_policies
@@ -304,7 +305,7 @@ export class AutoRouter {
           securityRequired: policyRow.security_required === 1,
           alwaysConfirmIntent: policyRow.always_confirm_intent === 1,
           customConstraints: policyRow.custom_constraints
-            ? (JSON.parse(policyRow.custom_constraints) as Array<{ readonly type: string; readonly value: unknown; readonly reason: string }>)
+            ? (JSON.parse(policyRow.custom_constraints) as Constraint[])
             : undefined,
           isActive: true,
           createdAt: Date.now(),
@@ -364,8 +365,8 @@ export class AutoRouter {
 
       // Phase 5: Initialize ConversationTracker for narrative monitoring
       const { getDb } = await import('@third-eye/db');
-      const { db } = getDb();
-      const conversationTracker = new ConversationTracker(db);
+      const { sqlite } = getDb();
+      const conversationTracker = new ConversationTracker(sqlite);
 
       // Log routing decision
       conversationTracker.logRoutingDecision(
@@ -403,7 +404,7 @@ export class AutoRouter {
         conversationTracker.logAgentMessage(
           decision.sessionId,
           eyeName,
-          result.md || result.summary || 'Eye completed execution',
+          result.md || 'Eye completed execution',
           {
             code: result.code,
             ok: result.ok,
@@ -432,17 +433,15 @@ export class AutoRouter {
         if (result.code === EyeStatusCode.E_NEEDS_CLARIFICATION) {
           const { PauseResumeManager } = await import('./pause-resume-manager');
           const { getDb } = await import('@third-eye/db');
-          const { db } = getDb();
-          const pauseManager = new PauseResumeManager(db);
+          const { sqlite } = getDb();
+          const pauseManager = new PauseResumeManager(sqlite);
 
           await pauseManager.pausePipeline({
             sessionId: decision.sessionId,
             currentEye: eyeName,
-            currentEyeIndex: i,
-            remainingEyes: decision.recommendedFlow.slice(i + 1),
             reason: 'clarification',
             pendingData: result.data,
-            expiresAt: Date.now() + 24 * 60 * 60 * 1000 // 24 hours
+            expiresInMs: 24 * 60 * 60 * 1000 // 24 hours
           });
 
           conversationTracker.logPause(
@@ -473,29 +472,27 @@ export class AutoRouter {
         if (result.code === EyeStatusCode.E_INTENT_UNCONFIRMED) {
           const { PauseResumeManager } = await import('./pause-resume-manager');
           const { getDb } = await import('@third-eye/db');
-          const { db } = getDb();
-          const pauseManager = new PauseResumeManager(db);
+          const { sqlite } = getDb();
+          const pauseManager = new PauseResumeManager(sqlite);
 
           await pauseManager.pausePipeline({
             sessionId: decision.sessionId,
             currentEye: eyeName,
-            currentEyeIndex: i,
-            remainingEyes: decision.recommendedFlow.slice(i + 1),
-            reason: 'intent_confirmation',
+            reason: 'confirmation',
             pendingData: result.data,
-            expiresAt: Date.now() + 24 * 60 * 60 * 1000
+            expiresInMs: 24 * 60 * 60 * 1000
           });
 
           conversationTracker.logPause(
             decision.sessionId,
-            'intent_confirmation',
+            'confirmation',
             `Eye ${eyeName} requested intent confirmation`
           );
 
           if (ws) {
             ws.broadcastToSession(decision.sessionId, {
               type: 'pipeline_paused',
-              reason: 'intent_confirmation',
+              reason: 'confirmation',
               eye: eyeName,
               timestamp: Date.now()
             });
@@ -506,7 +503,7 @@ export class AutoRouter {
             results,
             completed: false,
             paused: true,
-            pauseReason: 'intent_confirmation'
+            pauseReason: 'confirmation'
           };
         }
 
@@ -517,7 +514,7 @@ export class AutoRouter {
             decision.sessionId,
             eyeName,
             `Pipeline rejected with code: ${result.code}`,
-            { code: result.code, summary: result.summary }
+            { code: result.code, message: result.md }
           );
 
           return {
@@ -554,8 +551,8 @@ export class AutoRouter {
       if (routing?.sessionId) {
         try {
           const { getDb } = await import('@third-eye/db');
-          const { db } = getDb();
-          const conversationTracker = new ConversationTracker(db);
+          const { sqlite } = getDb();
+          const conversationTracker = new ConversationTracker(sqlite);
           conversationTracker.logError(
             routing.sessionId,
             'auto-router',
@@ -659,8 +656,8 @@ export class AutoRouter {
 
       // Phase 5: Initialize ConversationTracker and log resume
       const { getDb } = await import('@third-eye/db');
-      const { db } = getDb();
-      const conversationTracker = new ConversationTracker(db);
+      const { sqlite } = getDb();
+      const conversationTracker = new ConversationTracker(sqlite);
       conversationTracker.logResume(
         sessionId,
         `Pipeline resumed with ${remainingEyes.length} remaining eyes: ${remainingEyes.join(', ')}`,
@@ -692,7 +689,7 @@ export class AutoRouter {
         conversationTracker.logAgentMessage(
           sessionId,
           eyeName,
-          result.md || result.summary || 'Eye completed execution',
+          result.md || 'Eye completed execution',
           {
             code: result.code,
             ok: result.ok,

--- a/packages/core/conversation-tracker.ts
+++ b/packages/core/conversation-tracker.ts
@@ -9,7 +9,7 @@
  * Per R13: Event types from constants
  */
 
-import type { Database } from 'better-sqlite3';
+import type { Database } from 'bun:sqlite';
 import { nanoid } from 'nanoid';
 
 /**

--- a/packages/core/intent-confirmation-manager.ts
+++ b/packages/core/intent-confirmation-manager.ts
@@ -12,7 +12,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import type { Database } from 'better-sqlite3';
+import type { Database } from 'bun:sqlite';
 
 /**
  * Intent confirmation request

--- a/packages/core/orchestrator.ts
+++ b/packages/core/orchestrator.ts
@@ -370,7 +370,7 @@ export class EyeOrchestrator {
             let personaPrompt: PersonaPrompt;
             if (dynamicRouterPersona && isOverseer) {
               // REPAIR_PLAN A4: Use function calling for dynamic router too
-              const { EYE_RESPONSE_TOOL } = await import('@third-eye/eyes/renderer/persona-renderer');
+              const { EYE_RESPONSE_TOOL } = await import('@third-eye/eyes/src/renderer/persona-renderer');
               personaPrompt = {
                 systemPrompt: dynamicRouterPersona,
                 userMessage: enrichedInput,

--- a/packages/core/pause-resume-manager.ts
+++ b/packages/core/pause-resume-manager.ts
@@ -10,7 +10,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import type { Database } from 'better-sqlite3';
+import type { Database } from 'bun:sqlite';
 
 /**
  * Pipeline state for pause/resume

--- a/packages/core/routing/policy-manager.ts
+++ b/packages/core/routing/policy-manager.ts
@@ -9,8 +9,8 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import type { Database } from 'better-sqlite3';
-import type { RoutingPolicy } from './routing-modes';
+import type { Database } from 'bun:sqlite';
+import type { RoutingPolicy, Constraint } from './routing-modes';
 import { PolicyValidator } from './policy-validator';
 
 /**
@@ -34,7 +34,7 @@ export class PolicyManager {
     minValidationEyes?: number;
     securityRequired?: boolean;
     alwaysConfirmIntent?: boolean;
-    customConstraints?: readonly { readonly type: string; readonly value: unknown; readonly reason: string }[];
+    customConstraints?: readonly Constraint[];
   }): Promise<RoutingPolicy> {
     const id = randomUUID();
     const createdAt = Date.now();
@@ -121,7 +121,7 @@ export class PolicyManager {
       securityRequired: row.security_required === 1,
       alwaysConfirmIntent: row.always_confirm_intent === 1,
       customConstraints: row.custom_constraints
-        ? (JSON.parse(row.custom_constraints) as Array<{ readonly type: string; readonly value: unknown; readonly reason: string }>)
+        ? (JSON.parse(row.custom_constraints) as Constraint[])
         : undefined,
       isActive: row.is_active === 1,
       createdAt: row.created_at,
@@ -134,7 +134,7 @@ export class PolicyManager {
   listPolicies(filters?: { isActive?: boolean }): readonly RoutingPolicy[] {
     let query = `SELECT id, name, description, mandatory_eyes, forbidden_eyes, min_validation_eyes, security_required, always_confirm_intent, custom_constraints, is_active, created_at
                  FROM routing_policies WHERE 1=1`;
-    const params: unknown[] = [];
+    const params: (string | number | boolean | null)[] = [];
 
     if (filters?.isActive !== undefined) {
       query += ` AND is_active = ?`;
@@ -167,7 +167,7 @@ export class PolicyManager {
       securityRequired: row.security_required === 1,
       alwaysConfirmIntent: row.always_confirm_intent === 1,
       customConstraints: row.custom_constraints
-        ? (JSON.parse(row.custom_constraints) as Array<{ readonly type: string; readonly value: unknown; readonly reason: string }>)
+        ? (JSON.parse(row.custom_constraints) as Constraint[])
         : undefined,
       isActive: row.is_active === 1,
       createdAt: row.created_at,
@@ -187,7 +187,7 @@ export class PolicyManager {
       minValidationEyes: number;
       securityRequired: boolean;
       alwaysConfirmIntent: boolean;
-      customConstraints: readonly { readonly type: string; readonly value: unknown; readonly reason: string }[];
+      customConstraints: readonly Constraint[];
       isActive: boolean;
     }>
   ): Promise<RoutingPolicy> {

--- a/packages/core/routing/template-executor.ts
+++ b/packages/core/routing/template-executor.ts
@@ -8,7 +8,7 @@
  */
 
 import type { PipelineTemplate } from './routing-modes';
-import type { Database } from 'better-sqlite3';
+import type { Database } from 'bun:sqlite';
 
 /**
  * Template execution result
@@ -201,7 +201,7 @@ export class TemplateExecutor {
   async listTemplates(filters?: { isPublic?: boolean; createdBy?: string }): Promise<readonly PipelineTemplate[]> {
     let query = `SELECT id, name, description, eyes, strict, auto_trigger_pattern, created_by, is_public, usage_count, created_at
                  FROM pipeline_templates WHERE 1=1`;
-    const params: unknown[] = [];
+    const params: (string | number | boolean | null)[] = [];
 
     if (filters?.isPublic !== undefined) {
       query += ` AND is_public = ?`;

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,7 +5,8 @@
     "rootDir": ".",
     "composite": true,
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "types": ["bun-types"]
   },
   "include": ["*.ts", "**/*.ts"],
   "exclude": ["dist", "node_modules", "**/__tests__/**/*", "**/*.test.ts"],

--- a/packages/mcp/server.ts
+++ b/packages/mcp/server.ts
@@ -62,6 +62,8 @@ interface MCPToolArguments {
   sessionId?: string;
   strictness?: Record<string, unknown>;
   context?: Record<string, unknown>;
+  confirmationId?: string;
+  confirmationResponse?: string;
 }
 
 function buildSessionMetadata(): Record<string, unknown> {
@@ -363,8 +365,8 @@ export function createMCPServer(): Server {
       if (confirmationId && confirmationResponse) {
         const { IntentConfirmationManager } = await import('@third-eye/core');
         const { getDb } = await import('@third-eye/db');
-        const { db } = getDb();
-        const confirmationManager = new IntentConfirmationManager(db);
+        const { sqlite } = getDb();
+        const confirmationManager = new IntentConfirmationManager(sqlite);
 
         // Submit the confirmation response
         const confirmation = await confirmationManager.submitConfirmation(confirmationId, {

--- a/packages/types/providers.ts
+++ b/packages/types/providers.ts
@@ -41,6 +41,20 @@ export const CompletionRequestSchema = z.object({
 export type CompletionRequest = z.infer<typeof CompletionRequestSchema>;
 
 /**
+ * Tool call from function calling API
+ */
+export const ToolCallSchema = z.object({
+  id: z.string(),
+  type: z.literal('function'),
+  function: z.object({
+    name: z.string(),
+    arguments: z.string(),
+  }),
+});
+
+export type ToolCall = z.infer<typeof ToolCallSchema>;
+
+/**
  * Completion response format
  * Matches the actual provider implementations in packages/providers/src/base.ts
  */
@@ -54,6 +68,7 @@ export const CompletionResponseSchema = z.object({
     total_tokens: z.number(),
   }).optional(),
   finish_reason: z.enum(['stop', 'length', 'content_filter', 'tool_calls']).optional(),
+  tool_calls: z.array(ToolCallSchema).optional(),
   // Legacy fields for backward compatibility
   tokensIn: z.number().optional(),
   tokensOut: z.number().optional(),


### PR DESCRIPTION
CRITICAL BUILD FIXES:

1. **Consolidated Migration File** (packages/db/migrations/)
   - Merged 0001_phase1_foundation.sql INTO 0000_v1_release.sql
   - Deleted 0001_phase1_foundation.sql (no more split migrations)
   - Added capability_tags column directly to eyes table CREATE statement
   - Added routing_mode, policy_id, template_id to sessions table
   - Added ALL Phase 1 tables in single migration file

2. **Fixed Provider Tool Call Types** (packages/providers/)
   - groq.ts: Map tool_calls to ensure id is required (not optional)
   - openrouter.ts: Map tool_calls to ensure id is required (not optional)
   - Fixed TS2322 error where ToolCall.id was optional but type requires it

3. **Fixed Eye Capabilities Type** (packages/config/)
   - Added explicit cast to readonly string[] in getEyesByCapability
   - Fixed TS2345 error where Object.entries lost type information

NOW READY TO BUILD AND RUN.