### PR TITLE
Fix backend startup issues on release/go-live branch

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -8,6 +8,7 @@
     "start": "bun run src/start.ts"
   },
   "dependencies": {
+    "@hono/zod-validator": "^0.4.1",
     "@third-eye/config": "workspace:*",
     "@third-eye/constants": "workspace:*",
     "@third-eye/core": "workspace:*",

--- a/apps/server/src/routes/conversation-events.ts
+++ b/apps/server/src/routes/conversation-events.ts
@@ -15,7 +15,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { db } from '../db';
+import { getDb } from '@third-eye/db';
 import { ConversationTracker } from '@third-eye/core/conversation-tracker';
 
 const app = new Hono();
@@ -43,7 +43,7 @@ app.get('/session/:sessionId', async (c) => {
       }, 400);
     }
 
-    const tracker = new ConversationTracker(db);
+    const tracker = new ConversationTracker(getDb());
     const events = tracker.getConversationTimeline(sessionId);
 
     return c.json({
@@ -75,7 +75,7 @@ app.get(
     try {
       const { limit } = c.req.valid('query');
 
-      const tracker = new ConversationTracker(db);
+      const tracker = new ConversationTracker(getDb());
       const events = tracker.getRecentEvents(limit);
 
       return c.json({
@@ -137,7 +137,7 @@ app.get('/session/:sessionId/type/:eventType', async (c) => {
       }, 400);
     }
 
-    const tracker = new ConversationTracker(db);
+    const tracker = new ConversationTracker(getDb());
     const events = tracker.getEventsByType(sessionId, eventType as any);
 
     return c.json({

--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
       "name": "@third-eye/server",
       "version": "1.0.0",
       "dependencies": {
+        "@hono/zod-validator": "^0.4.1",
         "@third-eye/config": "workspace:*",
         "@third-eye/constants": "workspace:*",
         "@third-eye/core": "workspace:*",
@@ -315,6 +316,8 @@
     "@formatjs/icu-skeleton-parser": ["@formatjs/icu-skeleton-parser@1.8.15", "", { "dependencies": { "@formatjs/ecma402-abstract": "2.3.5", "tslib": "^2.8.0" } }, "sha512-qNrKxWJmnWxin5U4A4Evy7C0rgRiNw3IqXu9OGuT31B8lDxBGl+OgT8kcq0ZVKK0gqA4l4SQB9x+SFAvLT5hcQ=="],
 
     "@formatjs/intl-localematcher": ["@formatjs/intl-localematcher@0.6.2", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA=="],
+
+    "@hono/zod-validator": ["@hono/zod-validator@0.4.3", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.19.1" } }, "sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -7,5 +7,4 @@ export default defineConfig({
   dbCredentials: {
     url: 'file:///tmp/dummy.db', // Not used for generate command
   },
-  casing: 'snake_case', // Map camelCase schema fields to snake_case database columns
 });


### PR DESCRIPTION
- Add missing @hono/zod-validator dependency to server package.json
- Fix incorrect import in conversation-events.ts (use @third-eye/db instead of ../db)
- Remove unsupported 'casing' property from drizzle.config.ts
- Update bun.lock after dependency installation
- Backend now starts successfully with all services operational

Backend services:
- MCP Server: http://127.0.0.1:7070
- UI Dashboard: http://127.0.0.1:3300
- Database: ~/.third-eye-mcp/mcp.db