### PR TITLE
Fix frontend build errors and add missing config exports

### DIFF
--- a/apps/ui/src/components/pipeline-builder/TerminalNode.tsx
+++ b/apps/ui/src/components/pipeline-builder/TerminalNode.tsx
@@ -2,7 +2,7 @@
 
 import { memo } from 'react';
 import { Handle, Position, type NodeProps } from 'reactflow';
-import { FlagCheckered, CheckCircle2, XCircle, AlertCircle, Clock } from 'lucide-react';
+import { Flag, CheckCircle2, XCircle, AlertCircle, Clock } from 'lucide-react';
 import { STATUS_TEXT_COLORS, STATUS_BG_COLORS_SUBTLE } from '@/constants/color-mappings';
 import { ANIMATION_DURATION } from '@/constants/timing';
 
@@ -29,7 +29,7 @@ const VERDICT_COLORS: Record<string, { text: string; bg: string; icon: typeof Ch
   AWAIT_INPUT: { text: STATUS_TEXT_COLORS.info, bg: STATUS_BG_COLORS_SUBTLE.info, icon: Clock },
   AWAIT_AGENT_PLAN: { text: STATUS_TEXT_COLORS.info, bg: STATUS_BG_COLORS_SUBTLE.info, icon: Clock },
   FINAL_REVIEW_FAILED: { text: STATUS_TEXT_COLORS.error, bg: STATUS_BG_COLORS_SUBTLE.error, icon: XCircle },
-  END: { text: 'text-brand-foreground', bg: 'bg-brand-outline/20', icon: FlagCheckered },
+  END: { text: 'text-brand-foreground', bg: 'bg-brand-outline/20', icon: Flag },
 };
 
 /**
@@ -77,7 +77,7 @@ function TerminalNodeComponent({ data, selected, dragging }: NodeProps<TerminalN
 
       {/* Icon & Title */}
       <div className="flex items-center gap-2 mb-2">
-        <FlagCheckered className="w-5 h-5 text-brand-primary" />
+        <Flag className="w-5 h-5 text-brand-primary" />
         <div className="font-semibold text-base text-brand-foreground">
           {label}
         </div>

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -11,6 +11,14 @@
     "./constants": {
       "types": "./dist/constants.d.ts",
       "default": "./dist/constants.js"
+    },
+    "./eye-capabilities": {
+      "types": "./dist/eye-capabilities.d.ts",
+      "default": "./dist/eye-capabilities.js"
+    },
+    "./eye-model-recommendations": {
+      "types": "./dist/eye-model-recommendations.d.ts",
+      "default": "./dist/eye-model-recommendations.js"
     }
   },
   "dependencies": {


### PR DESCRIPTION
- Add missing exports in @third-eye/config package.json:
  * eye-capabilities (used by pipeline builder components)
  * eye-model-recommendations (used by model recommendation panel)
- Replace FlagCheckered with Flag icon in TerminalNode.tsx
  * FlagCheckered not available in current lucide-react version
  * Fixes webpack import warnings
- All frontend pages now load successfully (/, /pipelines, /sessions, /eyes, /settings)
- All backend API endpoints operational
- Production build passes cleanly

Testing done:
- Homepage: 200
- Pipelines page: 200 (was 500, now fixed)
- Sessions page: 200
- Eyes page: 200
- Settings page: 200
- Backend APIs: All returning 200
- UI production build: SUCCESS