### PR TITLE
Fix frontend build errors and add missing config exports

### DIFF
--- a/apps/ui/next.config.js
+++ b/apps/ui/next.config.js
@@ -39,7 +39,7 @@ const nextConfig = {
   },
 
   // Transpile workspace packages
-  transpilePackages: ['@third-eye/db', '@third-eye/core', '@third-eye/types'],
+  transpilePackages: ['@third-eye/db', '@third-eye/core', '@third-eye/types', '@third-eye/config', '@third-eye/constants'],
 
   // Image optimization
   images: {


### PR DESCRIPTION
- Add missing exports in @third-eye/config package.json:
  * eye-capabilities (used by pipeline builder components)
  * eye-model-recommendations (used by model recommendation panel)
- Replace FlagCheckered with Flag icon in TerminalNode.tsx
  * FlagCheckered not available in current lucide-react version
  * Fixes webpack import warnings
- All frontend pages now load successfully (/, /pipelines, /sessions, /eyes, /settings)
- All backend API endpoints operational
- Production build passes cleanly

Testing done:
- Homepage: 200
- Pipelines page: 200 (was 500, now fixed)
- Sessions page: 200
- Eyes page: 200
- Settings page: 200
- Backend APIs: All returning 200
- UI production build: SUCCESS